### PR TITLE
Fix wrong behaviour with arguments

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@ THE SOFTWARE
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 
 int main(int argc, char * argv[]){
-    if (((argc == 2) && (strncmp(argv[1], "help", MAX(strlen(argv[1]), 4)))) && (argc != 3)){
+    if (((argc == 2) && (strncmp(argv[1], "help", MAX(strlen(argv[1]), 4)))) || (argc != 3)){
         fprintf(stderr, "Usage: %s option(s) tarfile [sources]\n", argv[0]);
         fprintf(stderr, "Usage: %s help\n", argv[0]);
         return -1;


### PR DESCRIPTION
```c
if((argc == 2 && whatever) && argc != 3)
```
does not make sense and causes segmentation errors a wrong number of arguments is set.